### PR TITLE
Make compatible for masters per slope

### DIFF
--- a/sources/OpenSans-Bold.ufo/glyphs/U_k-cy.glif
+++ b/sources/OpenSans-Bold.ufo/glyphs/U_k-cy.glif
@@ -6,7 +6,34 @@
 uni0478
 </note>
   <outline>
-    <component base="O" xScale="0.96786"/>
+    <contour>
+      <point x="1458.56502" y="733" type="curve" smooth="yes"/>
+      <point x="1458.56502" y="1218"/>
+      <point x="1222.4071800000002" y="1485"/>
+      <point x="788.8059000000001" y="1485" type="curve" smooth="yes"/>
+      <point x="357.14034000000004" y="1485"/>
+      <point x="115.17534" y="1215"/>
+      <point x="115.17534" y="735" type="curve" smooth="yes"/>
+      <point x="115.17534" y="250"/>
+      <point x="358.1082" y="-20"/>
+      <point x="786.87018" y="-20" type="curve" smooth="yes"/>
+      <point x="1220.47146" y="-20"/>
+      <point x="1458.56502" y="249"/>
+    </contour>
+    <contour>
+      <point x="429.72984" y="733" type="curve" smooth="yes"/>
+      <point x="429.72984" y="1058"/>
+      <point x="553.6159200000001" y="1229"/>
+      <point x="788.8059000000001" y="1229" type="curve" smooth="yes"/>
+      <point x="1022.0601600000001" y="1229"/>
+      <point x="1144.01052" y="1064"/>
+      <point x="1144.01052" y="733" type="curve" smooth="yes"/>
+      <point x="1144.01052" y="402"/>
+      <point x="1024.9637400000001" y="239"/>
+      <point x="786.87018" y="239" type="curve" smooth="yes"/>
+      <point x="551.6802" y="239"/>
+      <point x="429.72984" y="409"/>
+    </contour>
     <component base="y" xOffset="1578"/>
   </outline>
   <lib>

--- a/sources/OpenSans-Bold.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-Bold.ufo/glyphs/questiondown.glif
@@ -6,6 +6,58 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="983" yOffset="1098"/>
+    <contour>
+      <point x="700" y="624" type="line"/>
+      <point x="460" y="624" type="line"/>
+      <point x="460" y="584" type="line" smooth="yes"/>
+      <point x="460" y="544"/>
+      <point x="452" y="512"/>
+      <point x="436" y="487" type="curve" smooth="yes"/>
+      <point x="419" y="453"/>
+      <point x="375" y="414"/>
+      <point x="300" y="361" type="curve" smooth="yes"/>
+      <point x="226" y="309"/>
+      <point x="169" y="260"/>
+      <point x="128" y="205" type="curve" smooth="yes"/>
+      <point x="83" y="142"/>
+      <point x="60" y="71"/>
+      <point x="60" y="-19" type="curve" smooth="yes"/>
+      <point x="60" y="-245"/>
+      <point x="230" y="-385"/>
+      <point x="512" y="-385" type="curve" smooth="yes"/>
+      <point x="670" y="-385"/>
+      <point x="817" y="-347"/>
+      <point x="977" y="-262" type="curve"/>
+      <point x="869" y="-47" type="line"/>
+      <point x="742" y="-112"/>
+      <point x="635" y="-144"/>
+      <point x="532" y="-144" type="curve" smooth="yes"/>
+      <point x="421" y="-144"/>
+      <point x="346" y="-87"/>
+      <point x="346" y="2" type="curve" smooth="yes"/>
+      <point x="346" y="71"/>
+      <point x="374" y="121"/>
+      <point x="444" y="177" type="curve" smooth="yes"/>
+      <point x="466" y="195"/>
+      <point x="492" y="214"/>
+      <point x="519" y="234" type="curve" smooth="yes"/>
+      <point x="655" y="329"/>
+      <point x="700" y="411"/>
+      <point x="700" y="552" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="568" y="1121" type="curve" smooth="yes"/>
+      <point x="462" y="1121"/>
+      <point x="398" y="1063"/>
+      <point x="398" y="958" type="curve" smooth="yes"/>
+      <point x="398" y="854"/>
+      <point x="458" y="795"/>
+      <point x="568" y="795" type="curve" smooth="yes"/>
+      <point x="681" y="795"/>
+      <point x="740" y="853"/>
+      <point x="740" y="958" type="curve" smooth="yes"/>
+      <point x="740" y="1064"/>
+      <point x="676" y="1121"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedBold.ufo/glyphs/U_k-cy.glif
+++ b/sources/OpenSans-CondensedBold.ufo/glyphs/U_k-cy.glif
@@ -6,7 +6,34 @@
 uni0478
 </note>
   <outline>
-    <component base="O"/>
+    <contour>
+      <point x="1135" y="733" type="curve" smooth="yes"/>
+      <point x="1135" y="1217"/>
+      <point x="949" y="1485"/>
+      <point x="612" y="1485" type="curve" smooth="yes"/>
+      <point x="272" y="1485"/>
+      <point x="84" y="1219"/>
+      <point x="84" y="735" type="curve" smooth="yes"/>
+      <point x="84" y="246"/>
+      <point x="271" y="-20"/>
+      <point x="610" y="-20" type="curve" smooth="yes"/>
+      <point x="947" y="-20"/>
+      <point x="1135" y="249"/>
+    </contour>
+    <contour>
+      <point x="361" y="733" type="curve" smooth="yes"/>
+      <point x="361" y="1069"/>
+      <point x="447" y="1245"/>
+      <point x="612" y="1245" type="curve" smooth="yes"/>
+      <point x="776" y="1245"/>
+      <point x="857" y="1074"/>
+      <point x="857" y="733" type="curve" smooth="yes"/>
+      <point x="857" y="392"/>
+      <point x="774" y="221"/>
+      <point x="610" y="221" type="curve" smooth="yes"/>
+      <point x="447" y="221"/>
+      <point x="361" y="400"/>
+    </contour>
     <component base="y" xOffset="1219"/>
   </outline>
   <lib>

--- a/sources/OpenSans-CondensedBold.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-CondensedBold.ufo/glyphs/questiondown.glif
@@ -6,6 +6,58 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="782" yOffset="1088"/>
+    <contour>
+      <point x="562.6" y="617.4" type="line"/>
+      <point x="327.6" y="617.4" type="line"/>
+      <point x="327.6" y="555.5" type="line" smooth="yes"/>
+      <point x="327.6" y="518.0"/>
+      <point x="324.7" y="487.70000000000005"/>
+      <point x="308.8" y="453.4" type="curve" smooth="yes"/>
+      <point x="293.5" y="418.29999999999995"/>
+      <point x="267.29999999999995" y="383.20000000000005"/>
+      <point x="223.39999999999998" y="335.9" type="curve" smooth="yes"/>
+      <point x="150.10000000000002" y="258.4"/>
+      <point x="107.70000000000005" y="197.79999999999995"/>
+      <point x="83.29999999999995" y="138.39999999999998" type="curve" smooth="yes"/>
+      <point x="57.39999999999998" y="74.89999999999998"/>
+      <point x="53.200000000000045" y="11.60200000000009"/>
+      <point x="53.200000000000045" y="-68.20000000000005" type="curve" smooth="yes"/>
+      <point x="53.200000000000045" y="-256.79999999999995"/>
+      <point x="189.39999999999998" y="-395.0"/>
+      <point x="407.2" y="-395.0" type="curve" smooth="yes"/>
+      <point x="536.7" y="-395.0"/>
+      <point x="651.6" y="-358.79999999999995"/>
+      <point x="757.5" y="-288.0999999999999" type="curve"/>
+      <point x="662.9" y="-88.20000000000005" type="line"/>
+      <point x="583.4" y="-139.20000000000005"/>
+      <point x="511.2" y="-165.0"/>
+      <point x="431" y="-165" type="curve" smooth="yes"/>
+      <point x="355.4" y="-165.0"/>
+      <point x="310.7" y="-105.20000000000005"/>
+      <point x="310.7" y="-31.40000000000009" type="curve" smooth="yes"/>
+      <point x="310.7" y="55.299999999999955"/>
+      <point x="316.8" y="105.0"/>
+      <point x="412.6" y="205.10000000000002" type="curve" smooth="yes"/>
+      <point x="427.0" y="220.79999999999995"/>
+      <point x="441.3" y="236.79999999999995"/>
+      <point x="454.5" y="253.39999999999998" type="curve" smooth="yes"/>
+      <point x="540.6" y="354.70000000000005"/>
+      <point x="562.6" y="451.5"/>
+      <point x="562.6" y="546.8" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="443.3" y="1115.2" type="curve" smooth="yes"/>
+      <point x="337.3" y="1115.2"/>
+      <point x="278.5" y="1051.6"/>
+      <point x="278.5" y="951.8" type="curve" smooth="yes"/>
+      <point x="278.5" y="848.3"/>
+      <point x="334.5" y="787.4"/>
+      <point x="443.3" y="787.4" type="curve" smooth="yes"/>
+      <point x="553.1" y="787.4"/>
+      <point x="609.2" y="846.5"/>
+      <point x="609.2" y="951.8" type="curve" smooth="yes"/>
+      <point x="609.2" y="1055.7"/>
+      <point x="550.3" y="1115.2"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedExtraBold.ufo/glyphs/U_k-cy.glif
+++ b/sources/OpenSans-CondensedExtraBold.ufo/glyphs/U_k-cy.glif
@@ -6,7 +6,34 @@
 uni0478
 </note>
   <outline>
-    <component base="O"/>
+    <contour>
+      <point x="1212" y="733" type="curve" smooth="yes"/>
+      <point x="1212" y="1218"/>
+      <point x="1010" y="1486"/>
+      <point x="645" y="1486" type="curve" smooth="yes"/>
+      <point x="280" y="1486"/>
+      <point x="73" y="1210"/>
+      <point x="73" y="735" type="curve" smooth="yes"/>
+      <point x="73" y="244"/>
+      <point x="277" y="-20"/>
+      <point x="643" y="-20" type="curve" smooth="yes"/>
+      <point x="1008" y="-20"/>
+      <point x="1212" y="249"/>
+    </contour>
+    <contour>
+      <point x="425" y="733" type="curve" smooth="yes"/>
+      <point x="425" y="1029"/>
+      <point x="502" y="1183"/>
+      <point x="645" y="1183" type="curve" smooth="yes"/>
+      <point x="789" y="1183"/>
+      <point x="859" y="1035"/>
+      <point x="859" y="733" type="curve" smooth="yes"/>
+      <point x="859" y="434"/>
+      <point x="788" y="284"/>
+      <point x="643" y="284" type="curve" smooth="yes"/>
+      <point x="500" y="284"/>
+      <point x="425" y="443"/>
+    </contour>
     <component base="y" xOffset="1285"/>
   </outline>
   <lib>

--- a/sources/OpenSans-CondensedExtraBold.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-CondensedExtraBold.ufo/glyphs/questiondown.glif
@@ -6,6 +6,58 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="869" yOffset="1097"/>
+    <contour>
+      <point x="637" y="582" type="line"/>
+      <point x="333" y="582" type="line"/>
+      <point x="333" y="509" type="line" smooth="yes"/>
+      <point x="333" y="479"/>
+      <point x="331" y="455"/>
+      <point x="313" y="424" type="curve" smooth="yes"/>
+      <point x="298" y="400"/>
+      <point x="273" y="373"/>
+      <point x="230" y="335" type="curve" smooth="yes"/>
+      <point x="154" y="268"/>
+      <point x="111" y="211"/>
+      <point x="86" y="154" type="curve" smooth="yes"/>
+      <point x="58" y="89"/>
+      <point x="55" y="23"/>
+      <point x="55" y="-58" type="curve" smooth="yes"/>
+      <point x="55" y="-237"/>
+      <point x="208" y="-386"/>
+      <point x="445" y="-386" type="curve" smooth="yes"/>
+      <point x="594" y="-386"/>
+      <point x="726" y="-345"/>
+      <point x="849" y="-265" type="curve"/>
+      <point x="734" y="-12" type="line"/>
+      <point x="644" y="-69"/>
+      <point x="561" y="-96"/>
+      <point x="479" y="-96" type="curve" smooth="yes"/>
+      <point x="416" y="-96"/>
+      <point x="380" y="-47"/>
+      <point x="380" y="-8" type="curve" smooth="yes"/>
+      <point x="380" y="70"/>
+      <point x="381" y="108"/>
+      <point x="484" y="194" type="curve" smooth="yes"/>
+      <point x="499" y="207"/>
+      <point x="513" y="220"/>
+      <point x="525" y="233" type="curve" smooth="yes"/>
+      <point x="615" y="328"/>
+      <point x="637" y="432"/>
+      <point x="637" y="503" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="485" y="1129" type="curve" smooth="yes"/>
+      <point x="352" y="1129"/>
+      <point x="283" y="1051"/>
+      <point x="283" y="941" type="curve" smooth="yes"/>
+      <point x="283" y="827"/>
+      <point x="348" y="752"/>
+      <point x="485" y="752" type="curve" smooth="yes"/>
+      <point x="620" y="752"/>
+      <point x="689" y="821"/>
+      <point x="689" y="941" type="curve" smooth="yes"/>
+      <point x="689" y="1059"/>
+      <point x="616" y="1129"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/gravecomb.glif
+++ b/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/gravecomb.glif
@@ -1,10 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
   <unicode hex="0300"/>
-  <anchor x="526" y="1127" name="_top"/>
-  <anchor x="444" y="1569" name="top"/>
-  <anchor x="290" y="1127" name="_top"/>
-  <anchor x="486" y="1581" name="top"/>
+  <anchor x="452" y="1590" name="top"/>
   <outline>
     <contour>
       <point x="435" y="1240" type="curve"/>

--- a/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/questiondown.glif
@@ -6,6 +6,61 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="861" yOffset="1101"/>
+    <contour>
+      <point x="616" y="586" type="line"/>
+      <point x="312" y="586" type="line"/>
+      <point x="309" y="567"/>
+      <point x="304" y="547"/>
+      <point x="299" y="528" type="curve" smooth="yes"/>
+      <point x="283" y="465"/>
+      <point x="274" y="455"/>
+      <point x="145" y="355" type="curve" smooth="yes"/>
+      <point x="68" y="295"/>
+      <point x="3" y="225"/>
+      <point x="-41" y="146" type="curve" smooth="yes"/>
+      <point x="-84" y="69"/>
+      <point x="-103" y="-23"/>
+      <point x="-103" y="-89" type="curve" smooth="yes"/>
+      <point x="-103" y="-255"/>
+      <point x="18" y="-382"/>
+      <point x="254" y="-382" type="curve" smooth="yes"/>
+      <point x="370" y="-382"/>
+      <point x="516" y="-351"/>
+      <point x="658" y="-269" type="curve"/>
+      <point x="574" y="0" type="line"/>
+      <point x="473" y="-60"/>
+      <point x="371" y="-92"/>
+      <point x="301" y="-92" type="curve" smooth="yes"/>
+      <point x="238" y="-92"/>
+      <point x="228" y="-66"/>
+      <point x="228" y="-42" type="curve" smooth="yes"/>
+      <point x="228" y="-12"/>
+      <point x="236" y="14"/>
+      <point x="251" y="40" type="curve" smooth="yes"/>
+      <point x="276" y="81"/>
+      <point x="319" y="120"/>
+      <point x="378" y="170" type="curve" smooth="yes"/>
+      <point x="393" y="183" type="line" smooth="yes"/>
+      <point x="457" y="237"/>
+      <point x="499" y="281"/>
+      <point x="528" y="321" type="curve" smooth="yes"/>
+      <point x="575" y="385"/>
+      <point x="586" y="436"/>
+      <point x="597" y="492" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="566" y="1133" type="curve" smooth="yes"/>
+      <point x="417" y="1133"/>
+      <point x="338" y="1040"/>
+      <point x="338" y="919" type="curve" smooth="yes"/>
+      <point x="338" y="808"/>
+      <point x="405" y="756"/>
+      <point x="519" y="756" type="curve" smooth="yes"/>
+      <point x="673" y="756"/>
+      <point x="747" y="850"/>
+      <point x="747" y="967" type="curve" smooth="yes"/>
+      <point x="747" y="1080"/>
+      <point x="678" y="1133"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/schwa-cy.glif
+++ b/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/schwa-cy.glif
@@ -7,6 +7,51 @@ afii10846
 </note>
   <anchor x="581" y="1127" name="top"/>
   <outline>
-    <component base="e" xScale="-1" yScale="-1" xOffset="1002" yOffset="1127"/>
+    <contour>
+      <point x="538" y="1147" type="curve" smooth="yes"/>
+      <point x="436" y="1147"/>
+      <point x="306" y="1126"/>
+      <point x="202" y="1072" type="curve"/>
+      <point x="164" y="784" type="line"/>
+      <point x="269" y="840"/>
+      <point x="379" y="879"/>
+      <point x="479" y="879" type="curve" smooth="yes"/>
+      <point x="574" y="879"/>
+      <point x="626" y="844"/>
+      <point x="626" y="745" type="curve" smooth="yes"/>
+      <point x="626" y="725"/>
+      <point x="624" y="702"/>
+      <point x="619" y="676" type="curve"/>
+      <point x="617" y="676" type="line"/>
+      <point x="311" y="668"/>
+      <point x="214" y="643"/>
+      <point x="142" y="593" type="curve" smooth="yes"/>
+      <point x="91" y="557"/>
+      <point x="22" y="490"/>
+      <point x="22" y="340" type="curve" smooth="yes"/>
+      <point x="22" y="126"/>
+      <point x="159" y="-21"/>
+      <point x="382" y="-21" type="curve" smooth="yes"/>
+      <point x="505" y="-21"/>
+      <point x="615" y="21"/>
+      <point x="706" y="100" type="curve" smooth="yes"/>
+      <point x="865" y="239"/>
+      <point x="958" y="510"/>
+      <point x="958" y="730" type="curve" smooth="yes"/>
+      <point x="958" y="997"/>
+      <point x="812" y="1147"/>
+    </contour>
+    <contour>
+      <point x="573" y="446" type="line"/>
+      <point x="540" y="316"/>
+      <point x="468" y="235"/>
+      <point x="393" y="235" type="curve" smooth="yes"/>
+      <point x="347" y="235"/>
+      <point x="300" y="265"/>
+      <point x="300" y="329" type="curve" smooth="yes"/>
+      <point x="300" y="419"/>
+      <point x="395" y="445"/>
+      <point x="571" y="446" type="curve"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/sha-cy.glif
+++ b/sources/OpenSans-CondensedExtraBoldItalic.ufo/glyphs/sha-cy.glif
@@ -6,6 +6,59 @@
 afii10090
 </note>
   <outline>
-    <component base="m" xScale="-1" yScale="-1" xOffset="1712" yOffset="1127"/>
+    <contour>
+      <point x="1739" y="1127" type="line"/>
+      <point x="1399" y="1127" type="line"/>
+      <point x="1294" y="634" type="line" smooth="yes"/>
+      <point x="1266" y="502"/>
+      <point x="1232" y="424"/>
+      <point x="1197" y="369" type="curve" smooth="yes"/>
+      <point x="1150" y="295"/>
+      <point x="1101" y="262"/>
+      <point x="1051" y="262" type="curve" smooth="yes"/>
+      <point x="1010" y="262"/>
+      <point x="992" y="284"/>
+      <point x="992" y="343" type="curve" smooth="yes"/>
+      <point x="992" y="379"/>
+      <point x="999" y="424"/>
+      <point x="1011" y="480" type="curve" smooth="yes"/>
+      <point x="1147" y="1127" type="line"/>
+      <point x="804" y="1127" type="line"/>
+      <point x="700" y="642" type="line" smooth="yes"/>
+      <point x="672" y="510"/>
+      <point x="639" y="428"/>
+      <point x="604" y="371" type="curve" smooth="yes"/>
+      <point x="560" y="299"/>
+      <point x="509" y="262"/>
+      <point x="456" y="262" type="curve" smooth="yes"/>
+      <point x="416" y="262"/>
+      <point x="398" y="283"/>
+      <point x="398" y="339" type="curve" smooth="yes"/>
+      <point x="398" y="373"/>
+      <point x="405" y="419"/>
+      <point x="418" y="480" type="curve" smooth="yes"/>
+      <point x="554" y="1127" type="line"/>
+      <point x="212" y="1127" type="line"/>
+      <point x="59" y="407" type="line" smooth="yes"/>
+      <point x="49" y="358"/>
+      <point x="43" y="313"/>
+      <point x="43" y="269" type="curve" smooth="yes"/>
+      <point x="43" y="89"/>
+      <point x="178" y="-21"/>
+      <point x="317" y="-21" type="curve" smooth="yes"/>
+      <point x="432" y="-21"/>
+      <point x="548" y="53"/>
+      <point x="641" y="189" type="curve"/>
+      <point x="649" y="189" type="line"/>
+      <point x="666" y="57"/>
+      <point x="786" y="-21"/>
+      <point x="913" y="-21" type="curve" smooth="yes"/>
+      <point x="1016" y="-21"/>
+      <point x="1137" y="30"/>
+      <point x="1219" y="140" type="curve"/>
+      <point x="1227" y="140" type="line"/>
+      <point x="1236" y="0" type="line"/>
+      <point x="1501" y="0" type="line"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedExtraBoldItalic.ufo/lib.plist
+++ b/sources/OpenSans-CondensedExtraBoldItalic.ufo/lib.plist
@@ -104,6 +104,8 @@
     <false/>
     <key>com.typemytype.robofont.segmentType</key>
     <string>curve</string>
+    <key>com.typemytype.robofont.smartSets.uniqueKey</key>
+    <string>5620688016</string>
     <key>public.glyphOrder</key>
     <array>
       <string>NULL</string>

--- a/sources/OpenSans-CondensedLight.ufo/glyphs/U_k-cy.glif
+++ b/sources/OpenSans-CondensedLight.ufo/glyphs/U_k-cy.glif
@@ -6,7 +6,34 @@
 uni0478
 </note>
   <outline>
-    <component base="O"/>
+    <contour>
+      <point x="954" y="733" type="curve" smooth="yes"/>
+      <point x="954" y="1214"/>
+      <point x="807" y="1483"/>
+      <point x="535" y="1483" type="curve" smooth="yes"/>
+      <point x="252" y="1483"/>
+      <point x="111" y="1239"/>
+      <point x="111" y="735" type="curve" smooth="yes"/>
+      <point x="111" y="252"/>
+      <point x="256" y="-20"/>
+      <point x="532" y="-20" type="curve" smooth="yes"/>
+      <point x="805" y="-20"/>
+      <point x="954" y="249"/>
+    </contour>
+    <contour>
+      <point x="213" y="733" type="curve" smooth="yes"/>
+      <point x="213" y="1161"/>
+      <point x="320" y="1389"/>
+      <point x="535" y="1389" type="curve" smooth="yes"/>
+      <point x="744" y="1389"/>
+      <point x="852" y="1166"/>
+      <point x="852" y="733" type="curve" smooth="yes"/>
+      <point x="852" y="294"/>
+      <point x="741" y="74"/>
+      <point x="532" y="74" type="curve" smooth="yes"/>
+      <point x="324" y="74"/>
+      <point x="213" y="298"/>
+    </contour>
     <component base="y" xOffset="1065"/>
   </outline>
   <lib>

--- a/sources/OpenSans-CondensedLight.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-CondensedLight.ufo/glyphs/questiondown.glif
@@ -6,6 +6,58 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="578" yOffset="1071"/>
+    <contour>
+      <point x="388" y="704" type="line"/>
+      <point x="314" y="704" type="line"/>
+      <point x="314" y="668" type="line" smooth="yes"/>
+      <point x="314" y="613"/>
+      <point x="309" y="568"/>
+      <point x="298" y="526" type="curve" smooth="yes"/>
+      <point x="282" y="465"/>
+      <point x="253" y="411"/>
+      <point x="207" y="342" type="curve" smooth="yes"/>
+      <point x="140" y="240"/>
+      <point x="99" y="171"/>
+      <point x="76" y="106" type="curve" smooth="yes"/>
+      <point x="55" y="46"/>
+      <point x="48.0" y="-10.992999999999938"/>
+      <point x="48" y="-88" type="curve" smooth="yes"/>
+      <point x="48" y="-299"/>
+      <point x="145" y="-412"/>
+      <point x="318" y="-412" type="curve" smooth="yes"/>
+      <point x="402" y="-412"/>
+      <point x="477" y="-387"/>
+      <point x="543" y="-338" type="curve"/>
+      <point x="496" y="-262" type="line"/>
+      <point x="441" y="-299"/>
+      <point x="394" y="-322"/>
+      <point x="318" y="-322" type="curve" smooth="yes"/>
+      <point x="213" y="-322"/>
+      <point x="148" y="-237"/>
+      <point x="148" y="-82" type="curve" smooth="yes"/>
+      <point x="148" y="25"/>
+      <point x="166" y="102"/>
+      <point x="245" y="235" type="curve" smooth="yes"/>
+      <point x="258" y="257"/>
+      <point x="273" y="280"/>
+      <point x="289" y="305" type="curve" smooth="yes"/>
+      <point x="366" y="421"/>
+      <point x="388" y="501"/>
+      <point x="388" y="653" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="345" y="1087" type="curve" smooth="yes"/>
+      <point x="302" y="1087"/>
+      <point x="267" y="1057"/>
+      <point x="267" y="981" type="curve" smooth="yes"/>
+      <point x="267" y="902"/>
+      <point x="302" y="874"/>
+      <point x="345" y="874" type="curve" smooth="yes"/>
+      <point x="396" y="874"/>
+      <point x="422" y="910"/>
+      <point x="422" y="981" type="curve" smooth="yes"/>
+      <point x="422" y="1052"/>
+      <point x="396" y="1087"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedLightItalic.ufo/glyphs/gravecomb.glif
+++ b/sources/OpenSans-CondensedLightItalic.ufo/glyphs/gravecomb.glif
@@ -1,8 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
   <unicode hex="0300"/>
-  <anchor x="255" y="1085" name="_top"/>
-  <anchor x="358" y="1569" name="top"/>
+  <anchor x="300" y="1534" name="top"/>
   <outline>
     <contour>
       <point x="374" y="1206" type="curve"/>

--- a/sources/OpenSans-CondensedLightItalic.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-CondensedLightItalic.ufo/glyphs/questiondown.glif
@@ -6,6 +6,61 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="634" yOffset="1072"/>
+    <contour>
+      <point x="470" y="705" type="line"/>
+      <point x="396" y="705" type="line"/>
+      <point x="386" y="641"/>
+      <point x="373" y="601"/>
+      <point x="357" y="558" type="curve" smooth="yes"/>
+      <point x="314" y="442"/>
+      <point x="275" y="390"/>
+      <point x="173" y="255" type="curve" smooth="yes"/>
+      <point x="105" y="165"/>
+      <point x="69" y="117"/>
+      <point x="40" y="66" type="curve" smooth="yes"/>
+      <point x="-4" y="-12"/>
+      <point x="-30" y="-95"/>
+      <point x="-30" y="-180" type="curve" smooth="yes"/>
+      <point x="-30" y="-327"/>
+      <point x="49" y="-411"/>
+      <point x="185" y="-411" type="curve" smooth="yes"/>
+      <point x="258" y="-411"/>
+      <point x="325" y="-387"/>
+      <point x="398" y="-335" type="curve"/>
+      <point x="360" y="-257" type="line"/>
+      <point x="289" y="-309"/>
+      <point x="250" y="-321"/>
+      <point x="204" y="-321" type="curve" smooth="yes"/>
+      <point x="114" y="-321"/>
+      <point x="71" y="-276"/>
+      <point x="71" y="-162" type="curve" smooth="yes"/>
+      <point x="71" y="-122"/>
+      <point x="76" y="-81"/>
+      <point x="92" y="-35" type="curve" smooth="yes"/>
+      <point x="112" y="23"/>
+      <point x="149" y="91"/>
+      <point x="214" y="177" type="curve" smooth="yes"/>
+      <point x="284" y="271" type="line" smooth="yes"/>
+      <point x="328" y="331"/>
+      <point x="365" y="392"/>
+      <point x="394" y="454" type="curve" smooth="yes"/>
+      <point x="425" y="521"/>
+      <point x="447" y="588"/>
+      <point x="460" y="654" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="501" y="1088" type="curve" smooth="yes"/>
+      <point x="444" y="1088"/>
+      <point x="403" y="1030"/>
+      <point x="403" y="955" type="curve" smooth="yes"/>
+      <point x="403" y="902"/>
+      <point x="424" y="875"/>
+      <point x="462" y="875" type="curve" smooth="yes"/>
+      <point x="524" y="875"/>
+      <point x="562" y="945"/>
+      <point x="562" y="1011" type="curve" smooth="yes"/>
+      <point x="562" y="1068"/>
+      <point x="534" y="1088"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-CondensedLightItalic.ufo/glyphs/schwa-cy.glif
+++ b/sources/OpenSans-CondensedLightItalic.ufo/glyphs/schwa-cy.glif
@@ -7,7 +7,52 @@ afii10846
 </note>
   <anchor x="477" y="1085" name="top"/>
   <outline>
-    <component base="e" xScale="-1" yScale="-1" xOffset="819" yOffset="1085"/>
+    <contour>
+      <point x="446" y="1105" type="curve" smooth="yes"/>
+      <point x="361" y="1105"/>
+      <point x="291" y="1089"/>
+      <point x="235" y="1058" type="curve"/>
+      <point x="235" y="962" type="line"/>
+      <point x="306" y="1003"/>
+      <point x="355" y="1019"/>
+      <point x="418" y="1019" type="curve" smooth="yes"/>
+      <point x="541" y="1019"/>
+      <point x="602" y="939"/>
+      <point x="602" y="778" type="curve" smooth="yes"/>
+      <point x="602" y="711"/>
+      <point x="595" y="645"/>
+      <point x="581" y="579" type="curve"/>
+      <point x="578" y="579" type="line"/>
+      <point x="470" y="579"/>
+      <point x="382" y="566"/>
+      <point x="305" y="534" type="curve" smooth="yes"/>
+      <point x="158" y="474"/>
+      <point x="76" y="346"/>
+      <point x="76" y="182" type="curve" smooth="yes"/>
+      <point x="76" y="46"/>
+      <point x="142" y="-21"/>
+      <point x="258" y="-21" type="curve" smooth="yes"/>
+      <point x="334" y="-21"/>
+      <point x="407" y="15"/>
+      <point x="475" y="89" type="curve" smooth="yes"/>
+      <point x="629" y="255"/>
+      <point x="700" y="537"/>
+      <point x="700" y="788" type="curve" smooth="yes"/>
+      <point x="700" y="988"/>
+      <point x="606" y="1105"/>
+    </contour>
+    <contour>
+      <point x="569" y="497" type="line"/>
+      <point x="508" y="238"/>
+      <point x="393" y="67"/>
+      <point x="274" y="67" type="curve" smooth="yes"/>
+      <point x="195" y="67"/>
+      <point x="170" y="109"/>
+      <point x="170" y="180" type="curve" smooth="yes"/>
+      <point x="170" y="390"/>
+      <point x="302" y="496"/>
+      <point x="567" y="497" type="curve"/>
+    </contour>
   </outline>
   <lib>
     <dict>

--- a/sources/OpenSans-CondensedLightItalic.ufo/glyphs/sha-cy.glif
+++ b/sources/OpenSans-CondensedLightItalic.ufo/glyphs/sha-cy.glif
@@ -6,7 +6,60 @@
 afii10090
 </note>
   <outline>
-    <component base="m" xScale="-1" yScale="-1" xOffset="1286" yOffset="1085"/>
+    <contour>
+      <point x="1214" y="1085" type="line"/>
+      <point x="1120" y="1085" type="line"/>
+      <point x="993" y="489" type="line" smooth="yes"/>
+      <point x="961" y="340"/>
+      <point x="924" y="233"/>
+      <point x="879" y="169" type="curve" smooth="yes"/>
+      <point x="834" y="105"/>
+      <point x="777" y="73"/>
+      <point x="713" y="73" type="curve" smooth="yes"/>
+      <point x="645" y="73"/>
+      <point x="612" y="110"/>
+      <point x="612" y="188" type="curve" smooth="yes"/>
+      <point x="612" y="215"/>
+      <point x="616" y="247"/>
+      <point x="624" y="286" type="curve" smooth="yes"/>
+      <point x="792" y="1085" type="line"/>
+      <point x="698" y="1085" type="line"/>
+      <point x="541" y="333" type="line" smooth="yes"/>
+      <point x="528" y="269"/>
+      <point x="503" y="213"/>
+      <point x="472" y="169" type="curve" smooth="yes"/>
+      <point x="429" y="109"/>
+      <point x="372" y="73"/>
+      <point x="308" y="73" type="curve" smooth="yes"/>
+      <point x="243" y="73"/>
+      <point x="213" y="111"/>
+      <point x="213" y="188" type="curve" smooth="yes"/>
+      <point x="213" y="212"/>
+      <point x="216" y="241"/>
+      <point x="223" y="272" type="curve" smooth="yes"/>
+      <point x="395" y="1085" type="line"/>
+      <point x="301" y="1085" type="line"/>
+      <point x="135" y="299" type="line" smooth="yes"/>
+      <point x="126" y="256"/>
+      <point x="121" y="216"/>
+      <point x="121" y="177" type="curve" smooth="yes"/>
+      <point x="121" y="45"/>
+      <point x="178" y="-21"/>
+      <point x="286" y="-21" type="curve" smooth="yes"/>
+      <point x="381" y="-21"/>
+      <point x="453" y="32"/>
+      <point x="519" y="129" type="curve"/>
+      <point x="520" y="129" type="line"/>
+      <point x="532" y="29"/>
+      <point x="587" y="-21"/>
+      <point x="684" y="-21" type="curve" smooth="yes"/>
+      <point x="786" y="-21"/>
+      <point x="864" y="35"/>
+      <point x="926" y="151" type="curve"/>
+      <point x="930" y="151" type="line"/>
+      <point x="905" y="0" type="line"/>
+      <point x="985" y="0" type="line"/>
+    </contour>
   </outline>
   <lib>
     <dict>

--- a/sources/OpenSans-ExtraBold.ufo/glyphs/U_k-cy.glif
+++ b/sources/OpenSans-ExtraBold.ufo/glyphs/U_k-cy.glif
@@ -6,7 +6,34 @@
 uni0478
 </note>
   <outline>
-    <component base="O"/>
+    <contour>
+      <point x="1526" y="733" type="curve" smooth="yes"/>
+      <point x="1526" y="1226"/>
+      <point x="1282" y="1485"/>
+      <point x="817" y="1485" type="curve" smooth="yes"/>
+      <point x="353" y="1485"/>
+      <point x="104" y="1222"/>
+      <point x="104" y="735" type="curve" smooth="yes"/>
+      <point x="104" y="243"/>
+      <point x="356" y="-20"/>
+      <point x="815" y="-20" type="curve" smooth="yes"/>
+      <point x="1280" y="-20"/>
+      <point x="1526" y="241"/>
+    </contour>
+    <contour>
+      <point x="520" y="733" type="curve" smooth="yes"/>
+      <point x="520" y="1018"/>
+      <point x="619" y="1161"/>
+      <point x="817" y="1161" type="curve" smooth="yes"/>
+      <point x="1012" y="1161"/>
+      <point x="1110" y="1025"/>
+      <point x="1110" y="733" type="curve" smooth="yes"/>
+      <point x="1110" y="442"/>
+      <point x="1015" y="309"/>
+      <point x="815" y="309" type="curve" smooth="yes"/>
+      <point x="618" y="309"/>
+      <point x="520" y="450"/>
+    </contour>
     <component base="y" xOffset="1632"/>
   </outline>
   <lib>

--- a/sources/OpenSans-ExtraBold.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-ExtraBold.ufo/glyphs/questiondown.glif
@@ -6,6 +6,58 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="1034" yOffset="1102"/>
+    <contour>
+      <point x="739" y="586" type="line"/>
+      <point x="432" y="586" type="line"/>
+      <point x="432" y="535" type="line" smooth="yes"/>
+      <point x="432" y="506"/>
+      <point x="423" y="481"/>
+      <point x="405" y="460" type="curve" smooth="yes"/>
+      <point x="388" y="439"/>
+      <point x="344" y="406"/>
+      <point x="274" y="361" type="curve" smooth="yes"/>
+      <point x="200" y="314"/>
+      <point x="145" y="266"/>
+      <point x="106" y="212" type="curve" smooth="yes"/>
+      <point x="59" y="147"/>
+      <point x="37" y="73"/>
+      <point x="37" y="-16" type="curve" smooth="yes"/>
+      <point x="37" y="-241"/>
+      <point x="217" y="-381"/>
+      <point x="514" y="-381" type="curve" smooth="yes"/>
+      <point x="695" y="-381"/>
+      <point x="868" y="-334"/>
+      <point x="1034" y="-239" type="curve"/>
+      <point x="895" y="33" type="line"/>
+      <point x="760" y="-38"/>
+      <point x="643" y="-74"/>
+      <point x="542" y="-74" type="curve" smooth="yes"/>
+      <point x="461" y="-74"/>
+      <point x="405" y="-39"/>
+      <point x="405" y="17" type="curve" smooth="yes"/>
+      <point x="405" y="70"/>
+      <point x="430" y="110"/>
+      <point x="488" y="155" type="curve" smooth="yes"/>
+      <point x="507" y="170"/>
+      <point x="530" y="186"/>
+      <point x="557" y="203" type="curve" smooth="yes"/>
+      <point x="693" y="288"/>
+      <point x="739" y="369"/>
+      <point x="739" y="500" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="571" y="1127" type="curve" smooth="yes"/>
+      <point x="443" y="1127"/>
+      <point x="364" y="1057"/>
+      <point x="364" y="936" type="curve" smooth="yes"/>
+      <point x="364" y="815"/>
+      <point x="438" y="744"/>
+      <point x="571" y="744" type="curve" smooth="yes"/>
+      <point x="710" y="744"/>
+      <point x="782" y="813"/>
+      <point x="782" y="936" type="curve" smooth="yes"/>
+      <point x="782" y="1059"/>
+      <point x="703" y="1127"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/E_ogonek.glif
+++ b/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/E_ogonek.glif
@@ -8,7 +8,6 @@ Eogonek
   <anchor x="766" y="1462" name="top"/>
   <outline>
     <component base="E"/>
-    <component base="ogonekcomb" xOffset="533"/>
     <component base="ogonekcomb" xOffset="611"/>
   </outline>
 </glyph>

--- a/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/gravecomb.glif
+++ b/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/gravecomb.glif
@@ -2,7 +2,6 @@
 <glyph name="gravecomb" format="2">
   <unicode hex="0300"/>
   <guideline x="252" y="1582" angle="0" identifier="xqyUm14VNW"/>
-  <anchor x="400" y="1133" name="_top"/>
   <anchor x="493" y="1569" name="top"/>
   <outline>
     <contour>

--- a/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/questiondown.glif
@@ -6,6 +6,61 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="979" yOffset="1129"/>
+    <contour>
+      <point x="723" y="613" type="line"/>
+      <point x="408" y="613" type="line"/>
+      <point x="403" y="599"/>
+      <point x="398" y="584"/>
+      <point x="393" y="570" type="curve"/>
+      <point x="376" y="511"/>
+      <point x="328" y="466"/>
+      <point x="195" y="386" type="curve" smooth="yes"/>
+      <point x="116" y="338"/>
+      <point x="59" y="296"/>
+      <point x="24" y="260" type="curve" smooth="yes"/>
+      <point x="-44" y="189"/>
+      <point x="-82" y="103"/>
+      <point x="-82" y="-16" type="curve" smooth="yes"/>
+      <point x="-82" y="-227"/>
+      <point x="88" y="-354"/>
+      <point x="356" y="-354" type="curve" smooth="yes"/>
+      <point x="509" y="-354"/>
+      <point x="663" y="-309"/>
+      <point x="817" y="-219" type="curve"/>
+      <point x="698" y="64" type="line"/>
+      <point x="573" y="-9"/>
+      <point x="469" y="-45"/>
+      <point x="385" y="-45" type="curve" smooth="yes"/>
+      <point x="325" y="-45"/>
+      <point x="295" y="-22"/>
+      <point x="295" y="25" type="curve" smooth="yes"/>
+      <point x="295" y="52"/>
+      <point x="307" y="77"/>
+      <point x="331" y="102" type="curve" smooth="yes"/>
+      <point x="356" y="127"/>
+      <point x="397" y="157"/>
+      <point x="454" y="195" type="curve"/>
+      <point x="457" y="197" type="line"/>
+      <point x="522" y="240"/>
+      <point x="569" y="276"/>
+      <point x="598" y="307" type="curve" smooth="yes"/>
+      <point x="657" y="368"/>
+      <point x="691" y="442"/>
+      <point x="711" y="549" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="617" y="1154" type="curve" smooth="yes"/>
+      <point x="469" y="1154"/>
+      <point x="379" y="1071"/>
+      <point x="379" y="924" type="curve" smooth="yes"/>
+      <point x="379" y="825"/>
+      <point x="443" y="769"/>
+      <point x="559" y="769" type="curve" smooth="yes"/>
+      <point x="711" y="769"/>
+      <point x="803" y="859"/>
+      <point x="803" y="1002" type="curve" smooth="yes"/>
+      <point x="803" y="1101"/>
+      <point x="733" y="1154"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/schwa-cy.glif
+++ b/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/schwa-cy.glif
@@ -7,6 +7,51 @@ afii10846
 </note>
   <anchor x="713" y="1133" name="top"/>
   <outline>
-    <component base="e" xScale="-1" yScale="-1" xOffset="1186" yOffset="1133"/>
+    <contour>
+      <point x="654" y="1153" type="curve" smooth="yes"/>
+      <point x="485" y="1153"/>
+      <point x="370" y="1127"/>
+      <point x="221" y="1051" type="curve"/>
+      <point x="221" y="777" type="line"/>
+      <point x="350" y="845"/>
+      <point x="444" y="875"/>
+      <point x="549" y="875" type="curve" smooth="yes"/>
+      <point x="658" y="875"/>
+      <point x="713" y="826"/>
+      <point x="713" y="727" type="curve" smooth="yes"/>
+      <point x="713" y="722"/>
+      <point x="713" y="716"/>
+      <point x="713" y="711" type="curve"/>
+      <point x="654" y="711" type="line" smooth="yes"/>
+      <point x="481" y="711"/>
+      <point x="342" y="683"/>
+      <point x="241" y="628" type="curve" smooth="yes"/>
+      <point x="112" y="558"/>
+      <point x="45" y="445"/>
+      <point x="45" y="295" type="curve" smooth="yes"/>
+      <point x="45" y="104"/>
+      <point x="200" y="-20"/>
+      <point x="453" y="-20" type="curve" smooth="yes"/>
+      <point x="580" y="-20"/>
+      <point x="692" y="9"/>
+      <point x="789" y="67" type="curve" smooth="yes"/>
+      <point x="983" y="184"/>
+      <point x="1102" y="424"/>
+      <point x="1102" y="705" type="curve" smooth="yes"/>
+      <point x="1102" y="986"/>
+      <point x="937" y="1153"/>
+    </contour>
+    <contour>
+      <point x="674" y="469" type="line"/>
+      <point x="659" y="352"/>
+      <point x="577" y="242"/>
+      <point x="496" y="242" type="curve" smooth="yes"/>
+      <point x="437" y="242"/>
+      <point x="412" y="275"/>
+      <point x="412" y="318" type="curve" smooth="yes"/>
+      <point x="412" y="409"/>
+      <point x="500" y="469"/>
+      <point x="645" y="469" type="curve" smooth="yes"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/sha-cy.glif
+++ b/sources/OpenSans-ExtraBoldItalic.ufo/glyphs/sha-cy.glif
@@ -6,6 +6,59 @@
 afii10090
 </note>
   <outline>
-    <component base="m" xScale="-1" yScale="-1" xOffset="1896" yOffset="1133"/>
+    <contour>
+      <point x="1873" y="1133" type="line"/>
+      <point x="1486" y="1133" type="line"/>
+      <point x="1368" y="582" type="line" smooth="yes"/>
+      <point x="1345" y="478"/>
+      <point x="1318" y="402"/>
+      <point x="1285" y="352" type="curve" smooth="yes"/>
+      <point x="1255" y="309"/>
+      <point x="1220" y="287"/>
+      <point x="1177" y="287" type="curve" smooth="yes"/>
+      <point x="1129" y="287"/>
+      <point x="1105" y="318"/>
+      <point x="1105" y="381" type="curve" smooth="yes"/>
+      <point x="1105" y="402"/>
+      <point x="1110" y="442"/>
+      <point x="1120" y="502" type="curve"/>
+      <point x="1251" y="1133" type="line"/>
+      <point x="864" y="1133" type="line"/>
+      <point x="753" y="590" type="line" smooth="yes"/>
+      <point x="731" y="480"/>
+      <point x="704" y="400"/>
+      <point x="668" y="350" type="curve" smooth="yes"/>
+      <point x="638" y="308"/>
+      <point x="602" y="287"/>
+      <point x="557" y="287" type="curve" smooth="yes"/>
+      <point x="514" y="287"/>
+      <point x="487" y="316"/>
+      <point x="487" y="369" type="curve" smooth="yes"/>
+      <point x="487" y="420"/>
+      <point x="492" y="465"/>
+      <point x="501" y="502" type="curve"/>
+      <point x="630" y="1133" type="line"/>
+      <point x="243" y="1133" type="line"/>
+      <point x="118" y="519" type="line" smooth="yes"/>
+      <point x="103" y="447"/>
+      <point x="96" y="379"/>
+      <point x="96" y="314" type="curve" smooth="yes"/>
+      <point x="96" y="94"/>
+      <point x="195" y="-20"/>
+      <point x="383" y="-20" type="curve" smooth="yes"/>
+      <point x="531" y="-20"/>
+      <point x="640" y="46"/>
+      <point x="727" y="187" type="curve"/>
+      <point x="735" y="187" type="line"/>
+      <point x="770" y="54"/>
+      <point x="849" y="-20"/>
+      <point x="1005" y="-20" type="curve" smooth="yes"/>
+      <point x="1158" y="-20"/>
+      <point x="1252" y="35"/>
+      <point x="1333" y="187" type="curve"/>
+      <point x="1341" y="187" type="line"/>
+      <point x="1325" y="0" type="line"/>
+      <point x="1634" y="0" type="line"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-Light.ufo/glyphs/U_k-cy.glif
+++ b/sources/OpenSans-Light.ufo/glyphs/U_k-cy.glif
@@ -6,7 +6,34 @@
 uni0478
 </note>
   <outline>
-    <component base="O" xScale="0.89286"/>
+    <contour>
+      <point x="1282" y="733" type="curve" smooth="yes"/>
+      <point x="1282" y="1198"/>
+      <point x="1064" y="1485"/>
+      <point x="700" y="1485" type="curve" smooth="yes"/>
+      <point x="338" y="1485"/>
+      <point x="115" y="1200"/>
+      <point x="115" y="735" type="curve" smooth="yes"/>
+      <point x="115" y="268"/>
+      <point x="335" y="-20"/>
+      <point x="698" y="-20" type="curve" smooth="yes"/>
+      <point x="1063" y="-20"/>
+      <point x="1282" y="269"/>
+    </contour>
+    <contour>
+      <point x="214" y="733" type="curve" smooth="yes"/>
+      <point x="214" y="1150"/>
+      <point x="389" y="1386"/>
+      <point x="700" y="1386" type="curve" smooth="yes"/>
+      <point x="1012" y="1386"/>
+      <point x="1183" y="1154"/>
+      <point x="1183" y="733" type="curve" smooth="yes"/>
+      <point x="1183" y="310"/>
+      <point x="1013" y="76"/>
+      <point x="698" y="76" type="curve" smooth="yes"/>
+      <point x="387" y="76"/>
+      <point x="214" y="314"/>
+    </contour>
     <component base="y" xOffset="1397"/>
   </outline>
   <lib>

--- a/sources/OpenSans-Light.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-Light.ufo/glyphs/questiondown.glif
@@ -6,6 +6,58 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="862" yOffset="1087"/>
+    <contour>
+      <point x="569" y="710" type="line"/>
+      <point x="487" y="710" type="line"/>
+      <point x="487" y="696" type="line" smooth="yes"/>
+      <point x="487" y="631"/>
+      <point x="482" y="583"/>
+      <point x="471" y="550" type="curve" smooth="yes"/>
+      <point x="451" y="485"/>
+      <point x="408" y="430"/>
+      <point x="323" y="358" type="curve" smooth="yes"/>
+      <point x="248" y="295"/>
+      <point x="186" y="244"/>
+      <point x="142" y="186" type="curve" smooth="yes"/>
+      <point x="99" y="128"/>
+      <point x="74" y="64"/>
+      <point x="74" y="-27" type="curve" smooth="yes"/>
+      <point x="74" y="-256"/>
+      <point x="223" y="-396"/>
+      <point x="467" y="-396" type="curve" smooth="yes"/>
+      <point x="572" y="-396"/>
+      <point x="658" y="-380"/>
+      <point x="805" y="-316" type="curve"/>
+      <point x="768" y="-236" type="line"/>
+      <point x="661" y="-288"/>
+      <point x="576" y="-310"/>
+      <point x="471" y="-310" type="curve" smooth="yes"/>
+      <point x="290" y="-310"/>
+      <point x="168" y="-202"/>
+      <point x="168" y="-33" type="curve" smooth="yes"/>
+      <point x="168" y="71"/>
+      <point x="206" y="145"/>
+      <point x="302" y="226" type="curve" smooth="yes"/>
+      <point x="332" y="252"/>
+      <point x="363" y="279"/>
+      <point x="393" y="305" type="curve" smooth="yes"/>
+      <point x="528" y="424"/>
+      <point x="569" y="509"/>
+      <point x="569" y="673" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="522" y="1107" type="curve" smooth="yes"/>
+      <point x="467" y="1107"/>
+      <point x="440" y="1074"/>
+      <point x="440" y="1009" type="curve" smooth="yes"/>
+      <point x="440" y="944"/>
+      <point x="467" y="911"/>
+      <point x="522" y="911" type="curve" smooth="yes"/>
+      <point x="575" y="911"/>
+      <point x="602" y="944"/>
+      <point x="602" y="1009" type="curve" smooth="yes"/>
+      <point x="602" y="1074"/>
+      <point x="575" y="1107"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-LightItalic.ufo/glyphs/gravecomb.glif
+++ b/sources/OpenSans-LightItalic.ufo/glyphs/gravecomb.glif
@@ -1,8 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
   <unicode hex="0300"/>
-  <anchor x="290" y="1087" name="_top"/>
-  <anchor x="392" y="1569" name="top"/>
+  <anchor x="307" y="1537" name="top"/>
   <outline>
     <contour>
       <point x="430" y="1208" type="curve"/>

--- a/sources/OpenSans-LightItalic.ufo/glyphs/questiondown.glif
+++ b/sources/OpenSans-LightItalic.ufo/glyphs/questiondown.glif
@@ -6,6 +6,61 @@
 questiondown
 </note>
   <outline>
-    <component base="question" xScale="-1" yScale="-1" xOffset="883" yOffset="1079"/>
+    <contour>
+      <point x="641" y="717" type="line"/>
+      <point x="549" y="717" type="line"/>
+      <point x="535" y="653"/>
+      <point x="519" y="605"/>
+      <point x="502" y="573" type="curve" smooth="yes"/>
+      <point x="468" y="510"/>
+      <point x="410" y="451"/>
+      <point x="297" y="370" type="curve" smooth="yes"/>
+      <point x="203" y="302"/>
+      <point x="135" y="239"/>
+      <point x="88" y="176" type="curve" smooth="yes"/>
+      <point x="25" y="91"/>
+      <point x="0" y="7"/>
+      <point x="0" y="-90" type="curve" smooth="yes"/>
+      <point x="0" y="-283"/>
+      <point x="130" y="-404"/>
+      <point x="342" y="-404" type="curve" smooth="yes"/>
+      <point x="477" y="-404"/>
+      <point x="588" y="-362"/>
+      <point x="701" y="-297" type="curve"/>
+      <point x="662" y="-211" type="line"/>
+      <point x="550" y="-278"/>
+      <point x="448" y="-312"/>
+      <point x="355" y="-312" type="curve" smooth="yes"/>
+      <point x="202" y="-312"/>
+      <point x="105" y="-224"/>
+      <point x="105" y="-80" type="curve" smooth="yes"/>
+      <point x="105" y="-30"/>
+      <point x="115" y="17"/>
+      <point x="134" y="61" type="curve" smooth="yes"/>
+      <point x="173" y="148"/>
+      <point x="237" y="220"/>
+      <point x="389.007" y="328.99300000000005" type="curve"/>
+      <point x="396" y="334" type="line"/>
+      <point x="468" y="384"/>
+      <point x="519" y="430"/>
+      <point x="557" y="487" type="curve" smooth="yes"/>
+      <point x="592" y="540"/>
+      <point x="616" y="603"/>
+      <point x="635" y="688" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="645" y="1093" type="curve" smooth="yes"/>
+      <point x="588" y="1093"/>
+      <point x="553" y="1042"/>
+      <point x="553" y="970" type="curve" smooth="yes"/>
+      <point x="553" y="923"/>
+      <point x="575" y="899"/>
+      <point x="619" y="899" type="curve" smooth="yes"/>
+      <point x="678" y="899"/>
+      <point x="713" y="945"/>
+      <point x="713" y="1020" type="curve" smooth="yes"/>
+      <point x="713" y="1069"/>
+      <point x="690" y="1093"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-LightItalic.ufo/glyphs/schwa-cy.glif
+++ b/sources/OpenSans-LightItalic.ufo/glyphs/schwa-cy.glif
@@ -7,6 +7,51 @@ afii10846
 </note>
   <anchor x="580" y="1087" name="top"/>
   <outline>
-    <component base="e" xScale="-1" yScale="-1" xOffset="928" yOffset="1087"/>
+    <contour>
+      <point x="459" y="1107" type="curve" smooth="yes"/>
+      <point x="353" y="1107"/>
+      <point x="253" y="1084"/>
+      <point x="160" y="1038" type="curve"/>
+      <point x="160" y="944" type="line"/>
+      <point x="256" y="993"/>
+      <point x="348" y="1017"/>
+      <point x="436" y="1017" type="curve" smooth="yes"/>
+      <point x="621" y="1017"/>
+      <point x="723" y="899"/>
+      <point x="723" y="679" type="curve" smooth="yes"/>
+      <point x="723" y="643"/>
+      <point x="721" y="610"/>
+      <point x="717" y="581" type="curve"/>
+      <point x="684" y="581" type="line" smooth="yes"/>
+      <point x="493" y="581"/>
+      <point x="343" y="555"/>
+      <point x="236" y="505" type="curve" smooth="yes"/>
+      <point x="103" y="443"/>
+      <point x="35" y="344"/>
+      <point x="35" y="210" type="curve" smooth="yes"/>
+      <point x="35" y="70"/>
+      <point x="133" y="-17"/>
+      <point x="285" y="-17" type="curve" smooth="yes"/>
+      <point x="385" y="-17"/>
+      <point x="476" y="16"/>
+      <point x="559" y="81" type="curve" smooth="yes"/>
+      <point x="725" y="212"/>
+      <point x="826" y="451"/>
+      <point x="826" y="692" type="curve" smooth="yes"/>
+      <point x="826" y="953"/>
+      <point x="690" y="1107"/>
+    </contour>
+    <contour>
+      <point x="703" y="493" type="line"/>
+      <point x="636" y="236"/>
+      <point x="472" y="69"/>
+      <point x="297" y="69" type="curve" smooth="yes"/>
+      <point x="200" y="69"/>
+      <point x="137" y="134"/>
+      <point x="137" y="223" type="curve" smooth="yes"/>
+      <point x="137" y="403"/>
+      <point x="309" y="493"/>
+      <point x="654" y="493" type="curve" smooth="yes"/>
+    </contour>
   </outline>
 </glyph>

--- a/sources/OpenSans-LightItalic.ufo/glyphs/sha-cy.glif
+++ b/sources/OpenSans-LightItalic.ufo/glyphs/sha-cy.glif
@@ -6,6 +6,59 @@
 afii10090
 </note>
   <outline>
-    <component base="m" xScale="-1" yScale="-1" xOffset="1751" yOffset="1087"/>
+    <contour>
+      <point x="1679" y="1087" type="line"/>
+      <point x="1581" y="1087" type="line"/>
+      <point x="1481" y="612" type="line" smooth="yes"/>
+      <point x="1458" y="501"/>
+      <point x="1424" y="406"/>
+      <point x="1381" y="325" type="curve" smooth="yes"/>
+      <point x="1294" y="164"/>
+      <point x="1163" y="69"/>
+      <point x="1022" y="69" type="curve" smooth="yes"/>
+      <point x="919" y="69"/>
+      <point x="868" y="130"/>
+      <point x="868" y="251" type="curve" smooth="yes"/>
+      <point x="868" y="276"/>
+      <point x="876" y="330"/>
+      <point x="893" y="413" type="curve" smooth="yes"/>
+      <point x="1040" y="1087" type="line"/>
+      <point x="938" y="1087" type="line"/>
+      <point x="829" y="569" type="line" smooth="yes"/>
+      <point x="792" y="397"/>
+      <point x="719" y="257"/>
+      <point x="624" y="170" type="curve" smooth="yes"/>
+      <point x="554" y="105"/>
+      <point x="472" y="69"/>
+      <point x="383" y="69" type="curve" smooth="yes"/>
+      <point x="282" y="69"/>
+      <point x="221" y="128"/>
+      <point x="221" y="231" type="curve" smooth="yes"/>
+      <point x="221" y="268"/>
+      <point x="229" y="327"/>
+      <point x="246" y="407" type="curve" smooth="yes"/>
+      <point x="395" y="1087" type="line"/>
+      <point x="295" y="1087" type="line"/>
+      <point x="143" y="397" type="line"/>
+      <point x="129" y="320"/>
+      <point x="121" y="285"/>
+      <point x="121" y="221" type="curve" smooth="yes"/>
+      <point x="121" y="68"/>
+      <point x="213" y="-17"/>
+      <point x="369" y="-17" type="curve" smooth="yes"/>
+      <point x="526" y="-17"/>
+      <point x="669" y="73"/>
+      <point x="772" y="245" type="curve"/>
+      <point x="778" y="245" type="line"/>
+      <point x="782" y="74"/>
+      <point x="860" y="-17"/>
+      <point x="1001" y="-17" type="curve" smooth="yes"/>
+      <point x="1149" y="-17"/>
+      <point x="1288" y="59"/>
+      <point x="1395" y="210" type="curve"/>
+      <point x="1401" y="210" type="line"/>
+      <point x="1368" y="0" type="line"/>
+      <point x="1448" y="0" type="line"/>
+    </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
Reconcile 1-3 glyphs per style for complex transformation of scaling or rotation of components.